### PR TITLE
introduce ci checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,28 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest-testinfra
+      
+      - name: Test with testinfra
+        run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,5 +38,10 @@ jobs:
         run: |
           docker-compose run tdk
 
+      - name: Debug
+        run: |
+          docker-compose ps
+          docker-compose exec output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
+
       - name: Verify results
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,5 +45,5 @@ jobs:
           docker-compose exec output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
 
       - name: Verify results
-        shell: 'script -q -e -c "bash {0}"'
+        # shell: 'script -q -e -c "bash {0}"'
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:
@@ -27,7 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest-testinfra
+          pip install pytest-testinfra yamllint
+
+      - name: Verify yamls
+        run: |
+          yamllint -sd relaxed .
 
       - name: Build docker-compose
         run: |
@@ -38,12 +42,5 @@ jobs:
         run: |
           docker-compose run tdk
 
-      - name: Debug
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          docker-compose ps
-          docker-compose exec output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
-
       - name: Verify results
-        # shell: 'script -q -e -c "bash {0}"'
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,9 +39,10 @@ jobs:
           docker-compose run tdk
 
       - name: Debug
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           docker-compose ps
-          docker-compose exec -t output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
+          docker-compose exec output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
 
       - name: Verify results
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build docker-compose
         run: |
-          docker-compose publl
+          docker-compose pull
           docker-compose build
       
       - name: Test with testinfra

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,10 @@ jobs:
         run: |
           docker-compose pull
           docker-compose build
+          
+      - name: Run the workflow
+        run: |
+          docker-compose run tdk
       
-      - name: Test with testinfra
+      - name: Verify results
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest-testinfra
+
+      - name: Build docker-compose
+        run: |
+          docker-compose publl
+          docker-compose build
       
       - name: Test with testinfra
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Number generated entries / 10
         # Otherwise it is impossible to execute it on GHA runner
-        run: sed -i.bak -E 's/(: +[1-9](0|_)+)0/\1/g' config.yaml
+        run: |
+          sed -i.bak -E 's/(: +[1-9](0|_)+)0/\1/g' config.yaml
 
       - name: Install dependencies
         run: |
@@ -32,10 +33,10 @@ jobs:
         run: |
           docker-compose pull
           docker-compose build
-          
+
       - name: Run the workflow
         run: |
           docker-compose run tdk
-      
+
       - name: Verify results
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
-          
+
+      - name: Number generated entries / 10
+        # Otherwise it is impossible to execute it on GHA runner
+        run: sed -i.bak -E 's/(: +[1-9](0|_)+)0/\1/g' config.yaml
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Debug
         run: |
           docker-compose ps
-          docker-compose exec output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
+          docker-compose exec -t output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
 
       - name: Verify results
         run: py.test -v test_tdk.py

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,4 +45,5 @@ jobs:
           docker-compose exec output_db bash -c "psql -U postgres -t -c 'SELECT COUNT(*) FROM address'"
 
       - name: Verify results
+        shell: 'script -q -e -c "bash {0}"'
         run: py.test -v test_tdk.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/__pycache__
+/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /__pycache__
 /.cache
+*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM synthesizedio/synthesized-tdk-cli:latest
+USER root
+RUN apk --no-cache add wait4ports
+USER user

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A very simple (but no less powerful) TDK demo.
 ```
 git clone https://github.com/synthesized-io/tdk-docker-demo
 cd tdk-docker-demo
-docker-compose up
+docker-compose run tdk
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -22,18 +22,17 @@ tables:
           type: address_generator
           column_templates: [ "${city}" ]
 
-
   - table_name_with_schema: "public.address"
     target_row_number: 10_000
     transformations:
       - columns: [ "address", "address2" ]
         params:
           type: address_generator
-          column_templates: [
-            "${street_name}, ${house_number}, ${flat_number}, ${zip_code}",
-            "${country}, ${city}, ${street_name}, ${house_number}, ${flat_number}, ${zip_code}"
-          ]
-
+          column_templates:
+            - "${street_name}, ${house_number}, ${flat_number}, ${zip_code}"
+            - >
+              ${country}, ${city}, ${street_name}, ${house_number},
+              ${flat_number}, ${zip_code}
 
   - table_name_with_schema: "public.store"
     target_row_number: 5_000
@@ -46,7 +45,6 @@ tables:
           type: person_generator
           column_templates: ["${first_name}", "${last_name}", "${email}"]
 
-
   - table_name_with_schema: "public.customer"
     target_row_number: 100_000
     transformations:
@@ -55,29 +53,26 @@ tables:
           type: person_generator
           column_templates: ["${first_name}", "${last_name}", "${email}"]
 
-
   - table_name_with_schema: "public.film"
     target_row_number: 10_000
     transformations:
-    - columns:
-      - "rating"
-      params:
-        type: "categorical_generator"
-        categories:
-          type: string
-          values:
-          - "G"
-          - "PG"
-          - "PG-13"
-          - "R"
-          - "NC-17"
-        probabilities:
-        - 0.5
-        - 0.2
-        - 0.1
-        - 0.1
-        - 0.1
-
+      - columns: ["rating"]
+        params:
+          type: "categorical_generator"
+          categories:
+            type: string
+            values:
+              - "G"
+              - "PG"
+              - "PG-13"
+              - "R"
+              - "NC-17"
+          probabilities:
+            - 0.5
+            - 0.2
+            - 0.1
+            - 0.1
+            - 0.1
 
   - table_name_with_schema: "public.rental"
     target_row_number: 100_000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       PGDATA: /data/postgres
     volumes:
-       - ./pagila-schema.sql:/docker-entrypoint-initdb.d/pagila-schema.sql
+      - ./pagila-schema.sql:/docker-entrypoint-initdb.d/pagila-schema.sql
     ports:
       - "6000:5432"
     restart: unless-stopped
@@ -24,7 +24,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       PGDATA: /data/postgres
     volumes:
-       - ./pagila-schema.sql:/docker-entrypoint-initdb.d/pagila-schema.sql
+      - ./pagila-schema.sql:/docker-entrypoint-initdb.d/pagila-schema.sql
     ports:
       - "6001:5432"
     restart: unless-stopped
@@ -53,4 +53,6 @@ services:
       - input_db
       - output_db
     restart: on-failure
-    command: sh -c "wait4ports -q -t 60 tcp://input_db:5432 tcp://output_db:5432 ; cd /app ; java org.springframework.boot.loader.JarLauncher"
+    command: >
+      sh -c "wait4ports -q -t 60 tcp://input_db:5432 tcp://output_db:5432
+      ; cd /app ; java org.springframework.boot.loader.JarLauncher"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,8 @@ services:
 
   tdk:
     container_name: tdk
-    image: synthesizedio/synthesized-tdk-cli:latest
+    build:
+      context: .
     environment:
       SYNTHESIZED_INPUT_URL: jdbc:postgresql://input_db:5432/postgres
       SYNTHESIZED_INPUT_USERNAME: postgres
@@ -52,3 +53,4 @@ services:
       - input_db
       - output_db
     restart: on-failure
+    command: sh -c "wait4ports -q -t 60 tcp://input_db:5432 tcp://output_db:5432 ; cd /app ; java org.springframework.boot.loader.JarLauncher"

--- a/test_tdk.py
+++ b/test_tdk.py
@@ -1,7 +1,3 @@
-def test_run_tdk(host):
-    cmd = host.run('docker-compose run tdk')
-    assert cmd.rc == 0
-    
 def test_input_address_isempty(host):
     cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM address\'"')
     assert int(cmd.stdout) == 0

--- a/test_tdk.py
+++ b/test_tdk.py
@@ -1,15 +1,23 @@
-def test_input_address_isempty(host):
-    cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM address\'"')
-    assert int(cmd.stdout) == 0
-  
-def test_input_actor_isempty(host):
-    cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM actor\'"')
-    assert int(cmd.stdout) == 0
+import pytest
 
-def test_output_address_is_not_empty(host):
-    cmd = host.run('docker-compose exec output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM address\'"')
-    assert int(cmd.stdout) == 10000
+@pytest.mark.parametrize("table", [
+    "address",
+    "actor", 
+    "country",
+    "city",
+    "store"
+])
+def test_input_db_isempty(host, table):
+    cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM %s\'"' % table)
+    assert int(cmd.stdout) == 0
   
-def test_output_actor_is_not_empty(host):
-    cmd = host.run('docker-compose exec output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM actor\'"')
-    assert int(cmd.stdout) == 10000
+@pytest.mark.parametrize("table,expected",   [
+    ("address",1000),
+    ("actor", 1000), 
+    ("country", 20),
+    ("city", 100),
+    ("store", 500)
+])
+def test_output_db_is_not_empty(host, table, expected):
+    cmd = host.run('docker-compose exec output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM %s\'"' % table)
+    assert int(cmd.stdout) == expected

--- a/test_tdk.py
+++ b/test_tdk.py
@@ -1,0 +1,19 @@
+def test_run_tdk(host):
+    cmd = host.run('docker-compose run tdk')
+    assert cmd.rc == 0
+    
+def test_input_address_isempty(host):
+    cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM address\'"')
+    assert int(cmd.stdout) == 0
+  
+def test_input_actor_isempty(host):
+    cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM actor\'"')
+    assert int(cmd.stdout) == 0
+
+def test_output_address_is_not_empty(host):
+    cmd = host.run('docker-compose exec output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM address\'"')
+    assert int(cmd.stdout) == 10000
+  
+def test_output_actor_is_not_empty(host):
+    cmd = host.run('docker-compose exec output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM actor\'"')
+    assert int(cmd.stdout) == 10000

--- a/test_tdk.py
+++ b/test_tdk.py
@@ -8,7 +8,7 @@ import pytest
     "store"
 ])
 def test_input_db_isempty(host, table):
-    cmd = host.run('docker-compose exec input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM %s\'"' % table)
+    cmd = host.run('docker-compose exec -T input_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM %s\'"' % table)
     assert int(cmd.stdout) == 0
   
 @pytest.mark.parametrize("table,expected",   [
@@ -19,5 +19,5 @@ def test_input_db_isempty(host, table):
     ("store", 500)
 ])
 def test_output_db_is_not_empty(host, table, expected):
-    cmd = host.run('docker-compose exec output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM %s\'"' % table)
+    cmd = host.run('docker-compose exec -T output_db bash -c "psql -U postgres -t -c \'SELECT COUNT(*) FROM %s\'"' % table)
     assert int(cmd.stdout) == expected


### PR DESCRIPTION
Introduce end-to-end CI checks for the provided example.
1. Added YamlLint utility with `relaxed` rule set. Now the build is going to fail if e. g. `config.yaml` will have incorrect indentations (which was the case).
2. The current example is not possible to run on standard GHA worker, so before actual run I use `sed` to edit `config.yaml` and decrease all the target row numbers by a factor of 10.
3. I also introduced `wait4ports` utility to tdk container which waits for databases to be available before running tdk. Using `wait4ports` for docker-compose startup synchronization, from my experience, is a nicely working practice. Besides that, it allows to use `docker-compose run tdk` instead of `docker-compose up` for running the example (no on-failure restarts are involved)
4. I use `docker-compose run` to run the actual example and then `testinfra` tests to verify the number of records in the source and target databases.